### PR TITLE
Use snprintf instead of sprintf.

### DIFF
--- a/ttmath/ttmathparser.h
+++ b/ttmath/ttmathparser.h
@@ -1523,7 +1523,7 @@ int i;
 	//warning C4996: 'sprintf': This function or variable may be unsafe.
 	#endif
 
-	sprintf(buf, "%d", par);
+	snprintf(buf, sizeof(buf), "%d", par);
 	for(i=0 ; buf[i] != 0 ; ++i)
 		buffer[i] = buf[i];
 

--- a/ttmath/ttmaththreads.h
+++ b/ttmath/ttmaththreads.h
@@ -94,7 +94,7 @@ namespace ttmath
 			// warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead.
 			#endif
 
-			sprintf(buffer, "TTMATH_LOCK_%ul", (unsigned long)GetCurrentProcessId());
+			snprintf(buffer, sizeof(buffer), "TTMATH_LOCK_%ul", (unsigned long)GetCurrentProcessId());
 
 			#ifdef _MSC_VER
 			#pragma warning (default : 4996)


### PR DESCRIPTION
`sprintf` has been deprecated and should be replaced with `snprintf`:
```
networkit/extlibs/ttmath/ttmath/ttmathparser.h:1526:2: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
        sprintf(buf, "%d", par);
```