### PR TITLE
Change Mul3Big3 to return success indicator.

### DIFF
--- a/ttmath/ttmathuint.h
+++ b/ttmath/ttmathuint.h
@@ -1344,7 +1344,7 @@ private:
 			   z1 = (x1 + x0)*(y1 + y0) - z2 - z0
 	*/
 	template<uint first_size, uint second_size, uint result_size>
-	void Mul3Big3(const uint * x1, const uint * x0, const uint * y1, const uint * y0, uint * result)
+	uint Mul3Big3(const uint * x1, const uint * x0, const uint * y1, const uint * y0, uint * result)
 	{
 	uint i, c, xc, yc;
 
@@ -1458,6 +1458,7 @@ private:
 			c = AddVector(result+first_size, z1.table, result_size-first_size, first_size*3, result+first_size);
 			TTMATH_ASSERT(c==0)
 		}
+	return c;
 	}
 
 


### PR DESCRIPTION
Other functions behave in the same way (declaring `unint c` and returning it as a success indicator). 

This also fixes a problem with the most recent AppleClang compiler, which complains about `c` being an unused variable when build in Release-mode. This was true in the old version, since c was assigned, but asserts comparing it were only triggered in Debug-mode. 